### PR TITLE
Do not set allowBackup as this is a library, applications can set it

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.androidbuts.multispinnerfilter" >
 
-    <application android:allowBackup="false">
+    <application>
 
     </application>
 


### PR DESCRIPTION
Hi, 

Thanks for the library, this is a small change not to set the application allowBackup setting, as this is a library if it's set applications will have to overwrite it in their manifest with 

Adding the tools namespace
```
<manifest
    xmlns:android="http://schemas.android.com/apk/res/android"
    xmlns:tools="http://schemas.android.com/tools"
```

Then adding this to the application

```
<application
        tools:replace="android:allowBackup"
```